### PR TITLE
Add dhcpcd/dnsmasq utility support

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom.bb
@@ -21,13 +21,13 @@ RDEPENDS:${PN} = "\
     "
 
 RDEPENDS:packagegroup-support-utils = "\
+    dhcpcd \
+    dnsmasq \
     libinput \
     libinput-bin \
     libnl \
     libxml2 \
     procps \
-    dhcpcd \
-    dnsmasq \
     "
 
 RDEPENDS:packagegroup-filesystem-utils = "\

--- a/recipes-products/packagegroups/packagegroup-qcom.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom.bb
@@ -26,6 +26,8 @@ RDEPENDS:packagegroup-support-utils = "\
     libnl \
     libxml2 \
     procps \
+    dhcpcd \
+    dnsmasq \
     "
 
 RDEPENDS:packagegroup-filesystem-utils = "\


### PR DESCRIPTION
This update integrates dhcpcd and dnsmasq to manage IP assignment for WiFi interfaces.