### PR TITLE
packagegroup-qcom: Enable networkmanager system daemon support

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom.bbappend
+++ b/recipes-products/packagegroups/packagegroup-qcom.bbappend
@@ -9,6 +9,7 @@ RDEPENDS:${PN}-support-utils = " \
     libinput \
     libinput-bin \
     procps \
+    networkmanager \
     "
 
 RDEPENDS:${PN}-filesystem-utils = " \

--- a/recipes-products/packagegroups/packagegroup-qcom.bbappend
+++ b/recipes-products/packagegroups/packagegroup-qcom.bbappend
@@ -8,8 +8,8 @@ PACKAGES += " \
 RDEPENDS:${PN}-support-utils = " \
     libinput \
     libinput-bin \
-    procps \
     networkmanager \
+    procps \
     "
 
 RDEPENDS:${PN}-filesystem-utils = " \


### PR DESCRIPTION
Add networkmanager system daemon support which includes dhcp & dnsmasq enablement and also WiFi STA connection is established using nmcli.